### PR TITLE
Cache busting: query strings not 100% effective

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,7 +176,12 @@ Forcing a Favicon Refresh
     .. code-block:: html
 
         <link rel="shortcut icon" href="http://www.yoursite.com/favicon.ico?v=2" />
+        
+* Some proxies and load balancers can fail to read query strings in edge cases. For large versioned deployments, put your version number in the filename. 
 
+    .. code-block:: html
+
+        <link rel="shortcut icon" href="http://www.yoursite.com/favicon-v2.ico" />
 FAQ
 ---
 


### PR DESCRIPTION
There are rare edge cases where query strings are stripped by proxies and load balancers. To be comprehensive, it's good to mention the safest method: putting the version number in the actual filename

Here's some good discussion with examples. http://stackoverflow.com/questions/9692665/cache-busting-via-params
