### PR TITLE
Added icon entry for Opera Coast browser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,6 +117,7 @@ Size    Name            Purpose
 144x144 favicon-144.png IE10 Metro tile for pinned site
 152x152 favicon-152.png iPad retina touch icon (Change for iOS 7: up from 144x144)
 195x195 favicon-195.png Opera Speed Dial icon
+228x228 favicon-228.png Opera Coast icon
 ======= =============== =======================================================================
 
 ICO File


### PR DESCRIPTION
Icon size specified in this blog post: http://my.opera.com/ODIN/blog/introducing-coast-by-opera
