### PR TITLE
Add Internet Explorer 11 tiles

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ If you're obsessive, you want all this too:
         <!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
         <link rel="apple-touch-icon-precomposed" href="/path/to/favicon-57.png">
 
-2. Largest to smallest Windows 8 and 8.1 tile icons [6]_:
+2. Largest to smallest Windows 8.1 tile icons [6]_:
 
     .. code-block:: html
 
@@ -85,9 +85,6 @@ If you're obsessive, you want all this too:
 
         <!-- For IE11 on Windows 8.1; "Medium" tile size -->
         <meta name="msapplication-square150x150logo" content="/path/to/favicon-150.png">
-
-        <!-- For IE10 on Windows 8; Metro tile icon -->
-        <meta name="msapplication-TileImage" content="/path/to/favicon-144.png">
 
         <!-- For IE11 on Windows 8.1; "Small" tile size -->
         <meta name="msapplication-square70x70logo" content="/path/to/favicon-70.png">


### PR DESCRIPTION
This adds information about IE 11 tiles for those who are hopelessly obsessive. :wink:

I'm still unclear on one piece of information in the documentation;

> Specifies the image to use as the medium tile, which is 150x150 pixels at 100% scaling.

I believe this means that it should actually be delivered in a larger format, however, I cannot find any Microsoft site which implements the IE11 tiles at this point to confirm the expected sizes.

According to [this KB article](http://msdn.microsoft.com/en-us/library/windows/apps/hh465362.aspx), for Windows Store apps, you're expected to support up to 180% scaling, so this might mean that the 150x150 `msapplication` image should actually be 270x270.

I don't think this is a problem in the immediate term, however, it might be worth investigating.
